### PR TITLE
Allow configurable table name

### DIFF
--- a/src/FootprintsServiceProvider.php
+++ b/src/FootprintsServiceProvider.php
@@ -33,12 +33,11 @@ class FootprintsServiceProvider extends ServiceProvider
      */
     protected function publishMigration()
     {
-        $published_migration = glob( database_path( '/migrations/*_create_visits_table.php' ) );
-        if( count( $published_migration ) === 0 )
-        {
-            $this->publishes([
-                   __DIR__.'/database/migrations/migrations.stub' => database_path('/migrations/'.date('Y_m_d_His').'_create_visits_table.php'),
-               ], 'migrations');
+        $published_migration = glob( database_path( '/migrations/*_create_footprints_table.php' ) );
+        if( count( $published_migration ) === 0 ) {
+          $this->publishes([
+            __DIR__ . '/database/migrations/migrations.stub' => database_path('/migrations/' . date('Y_m_d_His') . '_create_footprints_table.php'),
+          ], 'migrations');
         }
     }
 
@@ -49,8 +48,8 @@ class FootprintsServiceProvider extends ServiceProvider
     {
         // Bring in configuration values
         $this->mergeConfigFrom(
-              __DIR__.'/config/footprints.php', 'footprints'
-           );
+          __DIR__ . '/config/footprints.php', 'footprints'
+        );
 
         $this->app->singleton(Footprints::class, function () {
             return new Footprints();

--- a/src/TrackRegistrationAttribution.php
+++ b/src/TrackRegistrationAttribution.php
@@ -17,8 +17,8 @@ trait TrackRegistrationAttribution
 
         // Add an observer that upon registration will automatically sync up prior visits.
         static::created(function (Model $model) {
-                    $model->assignPreviousVisits();
-                });
+          $model->assignPreviousVisits();
+        });
     }
 
     /**
@@ -38,7 +38,9 @@ trait TrackRegistrationAttribution
      */
     private function assignPreviousVisits()
     {
-        return Visit::previousVisits()->update([config('footprints.column_name') => $this->id]);
+        return Visit::previousVisits()->update([
+          config('footprints.column_name') => $this->id
+        ]);
     }
 
     /**

--- a/src/Visit.php
+++ b/src/Visit.php
@@ -7,6 +7,13 @@ use Illuminate\Database\Eloquent\Model;
 
 class Visit extends Model
 {
+
+    /**
+     * The name of the database table
+     * @var string
+     */
+    protected $table = 'visits';
+
     /**
      * The attributes that aren't mass assignable.
      *
@@ -22,6 +29,20 @@ class Visit extends Model
     protected $dates = [
         'created_at', 'updated_at',
     ];
+
+
+    /**
+     * Constructor
+     * Override constructor to set the table name @ time of instantiation
+     */
+
+    public function __construct(array $attributes)
+    {
+        parent::__construct($attributes);
+        $this->setTable(config('footprints.table_name'));
+    }
+
+
 
     /**
      * Get the account that owns the visit.

--- a/src/config/footprints.php
+++ b/src/config/footprints.php
@@ -4,13 +4,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Table Name
+    |--------------------------------------------------------------------------
+    |
+    | The name of the database table that will hold UTM data
+    |
+    */
+    'table_name' => 'visits',
+
+    /*
+    |--------------------------------------------------------------------------
     | Model
     |--------------------------------------------------------------------------
     |
     | The model to track attribution events for.
     |
     */
-
     'model' => 'App\User',
 
     /*
@@ -21,7 +30,6 @@ return [
     | The column that defines the relation between tracked vists and the model.
     |
     */
-
     'column_name' => 'user_id',
 
     /*
@@ -32,7 +40,6 @@ return [
     | The name of the cookie that is set to keep track of attributions.
     |
     */
-
     'cookie_name' => 'footprints',
 
     /*
@@ -43,7 +50,5 @@ return [
     | How long since the initial visit should an attribution last for.
     |
     */
-
     'attribution_duration' => 2628000,
-
 ];

--- a/src/database/migrations/migrations.stub
+++ b/src/database/migrations/migrations.stub
@@ -3,7 +3,7 @@
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class CreateVisitsTable extends Migration
+class CreateFootprintsTable extends Migration
 {
     /**
      * Run the migrations.
@@ -12,7 +12,7 @@ class CreateVisitsTable extends Migration
      */
     public function up()
     {
-        Schema::create('visits', function (Blueprint $table) {
+        Schema::create(config('footprints.table_name'), function (Blueprint $table) {
             $table->increments('id');
             $table->integer(config('footprints.column_name'))->unsigned()->nullable();
             $table->string('cookie_token');
@@ -37,6 +37,6 @@ class CreateVisitsTable extends Migration
      */
     public function down()
     {
-        Schema::drop('visits');
+        Schema::drop(config('footprints.table_name'));
     }
 }

--- a/src/middleware/CaptureAttributionDataMiddleware.php
+++ b/src/middleware/CaptureAttributionDataMiddleware.php
@@ -132,21 +132,20 @@ class CaptureAttributionDataMiddleware
      */
     protected function trackVisit($attributionData, $cookieToken)
     {
-        return DB::table('visits')->insertGetId(
-            ['cookie_token' => $cookieToken,
-             'landing_page' => $attributionData['landing_page'],
-             'referrer_domain' => $attributionData['referrer']['referrer_domain'],
-             'referrer_url' => $attributionData['referrer']['referrer_url'],
-             'utm_source' => $attributionData['utm']['utm_source'],
-             'utm_campaign' => $attributionData['utm']['utm_campaign'],
-             'utm_medium' => $attributionData['utm']['utm_medium'],
-             'utm_term' => $attributionData['utm']['utm_term'],
-             'utm_content' => $attributionData['utm']['utm_content'],
-             'referral' => $attributionData['referral'],
-             'created_at' => date('Y-m-d H:i:s'),
-             'updated_at' => date('Y-m-d H:i:s'),
-            ]
-        );
+        return DB::table(config('footprints.table_name'))->insertGetId([
+          'cookie_token' => $cookieToken,
+          'landing_page' => $attributionData['landing_page'],
+          'referrer_domain' => $attributionData['referrer']['referrer_domain'],
+          'referrer_url' => $attributionData['referrer']['referrer_url'],
+          'utm_source' => $attributionData['utm']['utm_source'],
+          'utm_campaign' => $attributionData['utm']['utm_campaign'],
+          'utm_medium' => $attributionData['utm']['utm_medium'],
+          'utm_term' => $attributionData['utm']['utm_term'],
+          'utm_content' => $attributionData['utm']['utm_content'],
+          'referral' => $attributionData['referral'],
+          'created_at' => date('Y-m-d H:i:s'),
+          'updated_at' => date('Y-m-d H:i:s'),
+        ]);
     }
 
     /**


### PR DESCRIPTION
**What**: Add the option to configure the table name. Other changes are minor formatting tweaks.
**Why**: My DB administrator is very picky with naming conventions, so he wanted the ability to change it
**How**: Add `table_name` to the plugin's configuration, update the migration to use the new setting, then set the Eloquent model's `$table` attribute to the config value in its constructor.