### PR TITLE
Don’t assume User model primary key is called `id`

### DIFF
--- a/src/TrackRegistrationAttribution.php
+++ b/src/TrackRegistrationAttribution.php
@@ -39,7 +39,7 @@ trait TrackRegistrationAttribution
     public function assignPreviousVisits()
     {
         return Visit::previousVisits()->update([
-            config('footprints.column_name') => $this->id
+            config('footprints.column_name') => $this->getKey(),
         ]);
     }
 


### PR DESCRIPTION
The primary key on our User model isn't named `id`, this allows us  to grab the primary key whatever it is called.