### PR TITLE
Replace closures with Job classes

### DIFF
--- a/src/jobs/AssignPreviousVisits.php
+++ b/src/jobs/AssignPreviousVisits.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Kyranb\Footprints\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Cookie;
+use Kyranb\Footprints\Visit;
+
+class AssignPreviousVisits implements ShouldQueue
+{
+    use Queueable;
+
+    private $cookie;
+    private $id;
+
+    public function __construct($cookie, $id)
+    {
+        $this->cookie = $cookie;
+        $this->id = $id;
+    }
+
+    public function handle()
+    {
+        Visit::unassignedPreviousVisits($this->cookie)->update(
+            [
+                config('footprints.column_name') => $this->id
+            ]
+        );
+    }
+}

--- a/src/jobs/TrackVisit.php
+++ b/src/jobs/TrackVisit.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Kyranb\Footprints\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\Auth;
+use Kyranb\Footprints\Visit;
+
+class TrackVisit implements ShouldQueue
+{
+    use Queueable;
+
+    private $attributionData;
+    private $cookieToken;
+
+    public function __construct($attributionData, $cookieToken)
+    {
+        $this->attributionData = $attributionData;
+        $this->cookieToken = $cookieToken;
+    }
+
+    public function handle()
+    {
+        $user = [];
+        $user[config('footprints.column_name')] = Auth::user() ? Auth::user()->id : null;
+
+        $visit = Visit::create(array_merge([
+
+            'cookie_token'      => $this->cookieToken,
+            'landing_domain'    => $this->attributionData['landing_domain'],
+            'landing_page'      => $this->attributionData['landing_page'],
+            'landing_params'    => $this->attributionData['landing_params'],
+            'referrer_domain'   => $this->attributionData['referrer']['referrer_domain'],
+            'referrer_url'      => $this->attributionData['referrer']['referrer_url'],
+            'gclid'             => $this->attributionData['gclid'],
+            'utm_source'        => $this->attributionData['utm']['utm_source'],
+            'utm_campaign'      => $this->attributionData['utm']['utm_campaign'],
+            'utm_medium'        => $this->attributionData['utm']['utm_medium'],
+            'utm_term'          => $this->attributionData['utm']['utm_term'],
+            'utm_content'       => $this->attributionData['utm']['utm_content'],
+            'referral'          => $this->attributionData['referral'],
+            'created_at'        => $this->attributionData['created_at'],
+            'updated_at'        => $this->attributionData['updated_at'],
+        ], $this->attributionData['custom'], $user));
+
+        return $visit->id;
+    }
+}


### PR DESCRIPTION
This PR replaces the Closures, used to track a visit and attribute past visits, with explicit Job classes so they can be serialized correctly by the dispatcher.

This will fix the "Closure object cannot have properties" errors seen by some in Laravel 5.4+, see #16 