### PR TITLE
Refactor logging jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ Via Composer
 ``` bash
 $ composer require kyranb/footprints
 ```
-
-Add the service provider and (optionally) alias to their relative arrays in config/app.php:
+In Laravel 5.5 and up, the package will automatically register the service provider and facade but for Laravel versions below 5.5 add the service provider and (optionally) alias to their relative arrays in `config/app.php`:
 
 ``` php
 
@@ -48,21 +47,23 @@ Publish the config and migration files:
 php artisan vendor:publish --provider="Kyranb\Footprints\FootprintsServiceProvider"
 ```
 
-Add the ```TrackRegistrationAttribution``` trait to the model you wish to track attributions for. For example:
+The model where registration should be tracked (usually the Eloquent model `\App\Models\User`) must implement the `TrackableInterface` and tracking is automatically handled by simply using the `TrackRegistrationAttribution` trait.
 
-
+An implementation example can be seen here:
 
 ```php
 
-namespace App;
+namespace App\Models;
 
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Model;
+use Kyranb\Footprints\TrackableInterface;
 use Kyranb\Footprints\TrackRegistrationAttribution;
 
-class User extends Model
+class User extends Model implements TrackableInterface // <-- Added
 {
-    use Authenticatable, TrackRegistrationAttribution;
+    use Authenticatable;
+    use TrackRegistrationAttribution; // <-- Added 
 
     /**
      * The database table used by the model.
@@ -84,7 +85,7 @@ connection name (optional - if you need a separated tracking database):
 
 model name:
 
-``` 'model' => 'App\User' ```
+``` 'model' => 'App\Models\User' ```
 
 authentication guard:
 
@@ -187,7 +188,9 @@ $user->finalAttributionData();
 ### 2.x => 3.x
 Version 3.x of this package contains a few breaking changes that must be addressed if upgrading from earlier versions.
 - Add field `ip`' as a `nullable` `string` to the footprints table (table name configured in `config('footprints.table_name')`)
-- (optional | recommended) Publish the updated configuration file: `php artisan vendor:publish --provider="Kyranb\Footprints\FootprintsServiceProvider" --tag=config --force`  
+- Implement `TrackableInterface` on any models where the tracking should be tracked (usually the Eloquent model `User`)
+- (optional | recommended) Publish the updated configuration file: `php artisan vendor:publish --provider="Kyranb\Footprints\FootprintsServiceProvider" --tag=config --force`
+- If any modifications have been made to `TrackRegistrationAttribution` please consult the updated version to ensure proper compatability  
 
 ## Change log
 

--- a/src/Jobs/AssignPreviousVisits.php
+++ b/src/Jobs/AssignPreviousVisits.php
@@ -4,28 +4,24 @@ namespace Kyranb\Footprints\Jobs;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Cookie;
-use Kyranb\Footprints\Visit;
+use Illuminate\Http\Request;
+use Kyranb\Footprints\TrackableInterface;
 
 class AssignPreviousVisits implements ShouldQueue
 {
     use Queueable;
 
-    private $cookie;
-    private $id;
+    private $request;
+    private $trackable;
 
-    public function __construct($cookie, $id)
+    public function __construct(Request $request, TrackableInterface $trackable)
     {
-        $this->cookie = $cookie;
-        $this->id = $id;
+        $this->request = $request;
+        $this->trackable = $trackable;
     }
 
     public function handle()
     {
-        Visit::unassignedPreviousVisits($this->cookie)->update(
-            [
-                config('footprints.column_name') => $this->id
-            ]
-        );
+        $this->trackable->trackRegistration($this->request);
     }
 }

--- a/src/Jobs/TrackVisit.php
+++ b/src/Jobs/TrackVisit.php
@@ -11,10 +11,13 @@ class TrackVisit implements ShouldQueue
 {
     use Queueable;
 
-    private $attributionData;
-    private $cookieToken;
+    /** @var array */
+    protected $attributionData;
 
-    public function __construct($attributionData, $cookieToken)
+    /** @var string */
+    protected $cookieToken;
+
+    public function __construct(array $attributionData, string $cookieToken)
     {
         $this->attributionData = $attributionData;
         $this->cookieToken = $cookieToken;
@@ -22,28 +25,9 @@ class TrackVisit implements ShouldQueue
 
     public function handle()
     {
-        $user = [];
-        $user[config('footprints.column_name')] = Auth::user() ? Auth::user()->id : null;
-
-        $visit = Visit::create(array_merge([
+        Visit::create(array_merge([
             'cookie_token'      => $this->cookieToken,
-            'ip'                => $this->attributionData['ip'],
-            'landing_domain'    => $this->attributionData['landing_domain'],
-            'landing_page'      => $this->attributionData['landing_page'],
-            'landing_params'    => $this->attributionData['landing_params'],
-            'referrer_domain'   => $this->attributionData['referrer']['referrer_domain'],
-            'referrer_url'      => $this->attributionData['referrer']['referrer_url'],
-            'gclid'             => $this->attributionData['gclid'],
-            'utm_source'        => $this->attributionData['utm']['utm_source'],
-            'utm_campaign'      => $this->attributionData['utm']['utm_campaign'],
-            'utm_medium'        => $this->attributionData['utm']['utm_medium'],
-            'utm_term'          => $this->attributionData['utm']['utm_term'],
-            'utm_content'       => $this->attributionData['utm']['utm_content'],
-            'referral'          => $this->attributionData['referral'],
-            'created_at'        => $this->attributionData['created_at'],
-            'updated_at'        => $this->attributionData['updated_at'],
-        ], $this->attributionData['custom'], $user));
-
-        return $visit->id;
+            config('footprints.column_name') => Auth::user() ? Auth::user()->id : null,
+        ], $this->attributionData));
     }
 }

--- a/src/TrackableInterface.php
+++ b/src/TrackableInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Kyranb\Footprints;
+
+use Illuminate\Http\Request;
+
+interface TrackableInterface
+{
+    /**
+     * Assign earlier visits using current request.
+     */
+    public function trackRegistration(Request $request);
+}

--- a/src/TrackingLogger.php
+++ b/src/TrackingLogger.php
@@ -4,7 +4,6 @@ namespace Kyranb\Footprints;
 
 use Illuminate\Http\Response;
 use Illuminate\Http\Request;
-use Kyranb\Footprints\Visit;
 use Kyranb\Footprints\Jobs\TrackVisit;
 
 class TrackingLogger implements TrackingLoggerInterface
@@ -35,9 +34,6 @@ class TrackingLogger implements TrackingLoggerInterface
         $attributionData = $this->captureAttributionData();
         $cookieToken = $this->findOrCreateTrackingCookieToken();
 
-        $attributionData['created_at'] = date('Y-m-d H:i:s');
-        $attributionData['updated_at'] = date('Y-m-d H:i:s');
-
         $job = new TrackVisit($attributionData, $cookieToken);
         if (config('footprints.async') == true) {
             dispatch($job);
@@ -53,17 +49,19 @@ class TrackingLogger implements TrackingLoggerInterface
      */
     protected function captureAttributionData()
     {
-        return [
-            'ip'                => $this->captureIp(),
-            'landing_domain'    => $this->captureLandingDomain(),
-            'landing_page'      => $this->captureLandingPage(),
-            'landing_params'    => $this->captureLandingParams(),
-            'referrer'          => $this->captureReferrer(),
-            'gclid'             => $this->captureGCLID(),
-            'utm'               => $this->captureUTM(),
-            'referral'          => $this->captureReferral(),
-            'custom'            => $this->getCustomParameter(),
-        ];
+        return array_merge(
+            [
+                'ip'                => $this->captureIp(),
+                'landing_domain'    => $this->captureLandingDomain(),
+                'landing_page'      => $this->captureLandingPage(),
+                'landing_params'    => $this->captureLandingParams(),
+                'referral'          => $this->captureReferral(),
+                'gclid'             => $this->captureGCLID(),
+            ],
+            $this->captureUTM(),
+            $this->captureReferrer(),
+            $this->getCustomParameter()
+        );
     }
 
     /**

--- a/src/config/footprints.php
+++ b/src/config/footprints.php
@@ -30,7 +30,7 @@ return [
     | The model to track attribution events for.
     |
     */
-    'model' => 'App\User',
+    'model' => 'App\Models\User',
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
~DRAFT PR: until #37 and #38 are merged.~

This PR refactors the logging jobs by passing them any class that implements the `TrackableInterface` instead of just the id of the eloquent model.

This allows for much greater flexibility and would allow for tracking multiple models (closes #21) while it also makes it possible to make modifications like matching based on ip and headers (essentially closing #19).

Note this is a **breaking change** and notes about upgrading has been included in `README.md`