### PR TITLE
Add new event: RegistrationTracked

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ The default configuration tracks the most relevant information
 * `utm_content`
 * `created_at` (date of visit)
 
-But the package also makes it easy to the users ip address or bacially any information available from the request object.  
+But the package also makes it easy to the users ip address or basically any information available from the request object.  
 
 ##### Get all of a user's visits before registering.
 ``` php
@@ -178,10 +178,13 @@ $user = User::find(1);
 $user->finalAttributionData();
 ```
 
+##### Events
+The `TrackingLogger` emits an event `RegistrationTracked` once a registration has been processed while it is possible to listen for any visits tracked by simply listening for the [Eloquent Events](https://laravel.com/docs/eloquent#events) on the `Visit` model.
+
 ##### Tracking process in details
 First off the `CaptureAttributionDataMiddleware` can be registered globally or on a selected list of routes.
 
-Whenever an incomming request passes through the `CaptureAttributionDataMiddleware` middleware then it checks whether or not the request should be tracked using the class `TrackingFilter` (can be changed to any class implementing the `TrackingFilterInterface`) and if the request should be logged `TrackingLogger` will do so (can be changed to any class implementing `TrackingLoggerInterface`).
+Whenever an incoming request passes through the `CaptureAttributionDataMiddleware` middleware then it checks whether or not the request should be tracked using the class `TrackingFilter` (can be changed to any class implementing the `TrackingFilterInterface`) and if the request should be logged `TrackingLogger` will do so (can be changed to any class implementing `TrackingLoggerInterface`).
 
 The `TrackingLogger` is responsible for logging relevant information about the request as a `Vist` record. The most important parameter is the request's "footprint" which is the entity that *should* be the same for multiple requests performed by the same user and hence this is what is used to link different requests.
 

--- a/src/Events/RegistrationTracked.php
+++ b/src/Events/RegistrationTracked.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Kyranb\Footprints\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Kyranb\Footprints\TrackableInterface;
+
+class RegistrationTracked
+{
+    use Dispatchable, SerializesModels;
+
+    public TrackableInterface $trackable;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param TrackableInterface $trackable
+     * @return void
+     */
+    public function __construct(TrackableInterface $trackable)
+    {
+        $this->trackable = $trackable;
+    }
+}

--- a/src/Jobs/AssignPreviousVisits.php
+++ b/src/Jobs/AssignPreviousVisits.php
@@ -4,12 +4,16 @@ namespace Kyranb\Footprints\Jobs;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Http\Request;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Kyranb\Footprints\Events\RegistrationTracked;
 use Kyranb\Footprints\TrackableInterface;
 
 class AssignPreviousVisits implements ShouldQueue
 {
-    use Queueable;
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     protected Request $request;
     protected TrackableInterface $trackable;
@@ -23,5 +27,7 @@ class AssignPreviousVisits implements ShouldQueue
     public function handle()
     {
         $this->trackable->trackRegistration($this->request);
+
+        event(new RegistrationTracked($this->trackable));
     }
 }

--- a/src/TrackRegistrationAttribution.php
+++ b/src/TrackRegistrationAttribution.php
@@ -15,8 +15,6 @@ trait TrackRegistrationAttribution
 {
     public static function bootTrackRegistrationAttribution()
     {
-        $footprints = app(Footprints::class);
-
         // Add an observer that upon registration will automatically sync up prior visits.
         static::created(function (Model $model) {
             $model->assignPreviousVisits();

--- a/src/TrackingLogger.php
+++ b/src/TrackingLogger.php
@@ -15,7 +15,7 @@ class TrackingLogger implements TrackingLoggerInterface
     protected Request $request;
 
     /**
-     * Determine whether or not the request should be tracked.
+     * Track the request.
      *
      * @param \Illuminate\Http\Request $request
      * @return \Illuminate\Http\Request

--- a/src/Visit.php
+++ b/src/Visit.php
@@ -8,7 +8,8 @@ class Visit extends Model
 {
 
     /**
-     * The name of the database table
+     * The name of the database table.
+     *
      * @var string
      */
     protected $table = 'visits';
@@ -31,8 +32,7 @@ class Visit extends Model
     ];
 
     /**
-     * Constructor
-     * Override constructor to set the table name @ time of instantiation
+     * Override constructor to set the table name @ time of instantiation.
      *
      * @param array $attributes
      * @return void
@@ -51,6 +51,8 @@ class Visit extends Model
 
     /**
      * Get the account that owns the visit.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function account()
     {

--- a/tests/Unit/Jobs/AssignPreviousVisitsTest.php
+++ b/tests/Unit/Jobs/AssignPreviousVisitsTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Kyranb\Footprints\Tests\Unit\Jobs;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Event;
+use Kyranb\Footprints\Events\RegistrationTracked;
+use Kyranb\Footprints\Jobs\AssignPreviousVisits;
+use Kyranb\Footprints\Tests\TestCase;
+use Kyranb\Footprints\TrackableInterface;
+use Mockery\MockInterface;
+
+class AssignPreviousVisitsTest extends TestCase
+{
+    public function test_emits_event_registration_tracked()
+    {
+        $request = $this->mock(Request::class, function (MockInterface $mock) {
+            //
+        });
+
+        $trackable = $this->mock(TrackableInterface::class, function (MockInterface $mock) {
+            $mock->shouldReceive('trackRegistration')->once();
+        });
+
+        Event::fake();
+
+        $job = new AssignPreviousVisits($request, $trackable);
+        $job->handle(); // We are not checking the "queue" part of the job, only that it does actually dispatch the event
+
+        Event::assertDispatched(RegistrationTracked::class, function ($event) use ($trackable) {
+            return $event->trackable === $trackable;
+        });
+    }
+}


### PR DESCRIPTION
This PR implements an event `RegistrationTracked` which is emitted when a registration has been tracked.

This is very useful in situations where some external reporting or notification might be needed. Example: Send a slack notification that a new user has signed up (can be done using Eloquent model events) and include a list of UTM tags they have used lately (only possible with this PR).

p.s. This PR also fixes a few minor spelling errors and reference to a file that no longer exists.