### PR TITLE
Update composer description

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "kyranb/footprints",
     "type": "library",
-    "description": "A simple registration attribution tracking solution for Laravel 5.2+ (UTM Parameters and Referrers)",
+    "description": "A simple registration attribution tracking solution for Laravel (UTM Parameters and Referrers)",
     "keywords": [
         "footprints",
         "tracking",


### PR DESCRIPTION
The package description provided in `composer.json` is the one that can be seen on [Packagist](https://packagist.org/packages/kyranb/footprints) - this incorrectly states that the package supports Laravel 5.2+.

This PR removes the information about supported versions since this is already explained in `composer.json` as a dependency.

<img width="1199" alt="Screenshot 2021-02-27 at 13 42 30" src="https://user-images.githubusercontent.com/30228807/109387454-d9be7d00-7901-11eb-9fd4-5b23e827c34f.png">
