### PR TITLE
Mention new footprint column in v3 upgrade guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,9 @@ At some point the user signs up (or *any* trackable model is created) which fire
 
 ### 2.x => 3.x
 Version 3.x of this package contains a few breaking changes that must be addressed if upgrading from earlier versions.
-- Add field `ip`' as a `nullable` `string` to the footprints table (table name configured in `config('footprints.table_name')`)
+
+- Rename the `cookie_token` column to `footprint`, in the table configured in `config('footprints.table_name')`
+- Add field `ip`' as a `nullable` `string` to the configured footprints table
 - Implement `TrackableInterface` on any models where the tracking should be tracked (usually the Eloquent model `User`)
 - (optional | recommended) Publish the updated configuration file: `php artisan vendor:publish --provider="Kyranb\Footprints\FootprintsServiceProvider" --tag=config --force`
 - If any modifications have been made to `TrackRegistrationAttribution` please consult the updated version to ensure proper compatability  


### PR DESCRIPTION
After upgrading to v3 and getting a database error, I noticed the `cookie_token` column had been renamed in #41 — but until now, this hadn't been mentioned in the upgrade guide.

Thanks @kyranb and @bilfeldt, this is an invaluable package. Cheers!