### PR TITLE
Correct tracking logged users when queued

### DIFF
--- a/src/Jobs/TrackVisit.php
+++ b/src/Jobs/TrackVisit.php
@@ -4,7 +4,6 @@ namespace Kyranb\Footprints\Jobs;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Support\Facades\Auth;
 use Kyranb\Footprints\Visit;
 
 class TrackVisit implements ShouldQueue
@@ -12,16 +11,18 @@ class TrackVisit implements ShouldQueue
     use Queueable;
 
     protected array $attributionData;
+    public $trackableId;
 
-    public function __construct(array $attributionData)
+    public function __construct(array $attributionData, $trackableId = null)
     {
         $this->attributionData = $attributionData;
+        $this->trackableId = $trackableId;
     }
 
     public function handle()
     {
         Visit::create(array_merge([
-            config('footprints.column_name') => Auth::user() ? Auth::user()->id : null,
+            config('footprints.column_name') => $this->trackableId,
         ], $this->attributionData));
     }
 }

--- a/src/TrackingLogger.php
+++ b/src/TrackingLogger.php
@@ -4,6 +4,7 @@ namespace Kyranb\Footprints;
 
 use Illuminate\Http\Request;
 use Kyranb\Footprints\Jobs\TrackVisit;
+use Illuminate\Support\Facades\Auth;
 
 class TrackingLogger implements TrackingLoggerInterface
 {
@@ -24,7 +25,7 @@ class TrackingLogger implements TrackingLoggerInterface
     {
         $this->request = $request;
 
-        $job = new TrackVisit($this->captureAttributionData());
+        $job = new TrackVisit($this->captureAttributionData(), Auth::user() ? Auth::user()->id : null);
         if (config('footprints.async') == true) {
             dispatch($job);
         } else {


### PR DESCRIPTION
We should never have a call to Auth::user() in queued job. 
It should be passed by the dispatch function.

With the current implementation, logged-in users cannot be tracked/attributed when the configuration is set to queue jobs. 