### PR TITLE
 Correct ordering problem for initial and final attribution data

### DIFF
--- a/src/TrackRegistrationAttribution.php
+++ b/src/TrackRegistrationAttribution.php
@@ -63,7 +63,7 @@ trait TrackRegistrationAttribution
      */
     public function initialAttributionData()
     {
-        return $this->visits()->orderBy('created_at', 'asc')->first();
+        return $this->hasMany(Visit::class, config('footprints.column_name'))->orderBy('created_at', 'asc')->first();
     }
 
     /**
@@ -73,6 +73,6 @@ trait TrackRegistrationAttribution
      */
     public function finalAttributionData()
     {
-        return $this->visits()->orderBy('created_at', 'desc')->first();
+        return $this->hasMany(Visit::class, config('footprints.column_name'))->orderBy('created_at', 'desc')->first();
     }
 }


### PR DESCRIPTION
When calling initialAttributionData or finalAttributionData, it calls the visits() method which is already ordered.

In the current state, the initialAttributionData doesn't work because it will call the visit method which has already ordered the results by created_at descending.