### PR TITLE
Truncate attributes before saving to DB

### DIFF
--- a/src/TrackingLogger.php
+++ b/src/TrackingLogger.php
@@ -40,7 +40,7 @@ class TrackingLogger implements TrackingLoggerInterface
      */
     protected function captureAttributionData()
     {
-        return array_merge(
+        $attributes = array_merge(
             [
                 'footprint'         => $this->request->footprint(),
                 'ip'                => $this->captureIp(),
@@ -54,6 +54,8 @@ class TrackingLogger implements TrackingLoggerInterface
             $this->captureReferrer(),
             $this->getCustomParameter()
         );
+
+        return array_map(fn (?string $item) => is_string($item) ? substr($item, 0, 255) : $item, $attributes);
     }
 
     /**


### PR DESCRIPTION
This is a super simple implementation of attribute truncation which should solve #63 

@kyranb There are two things to note here:
- Backwards compatibility
- Open for modification

## Backwards compatibility

This can cause problems for anyone having modified the migration file and made the textfields "longer" or having implemented their own long text fields for custom parameters.

With this PR the columns will now be truncated to 255 characters. **But** I would consider this more of a theoretical issue  as in real life none of these parameters should (hopefully) be longer than 255 characters.

## Open for modification

This approach is not really open for modification as the truncation length is hardcoded in the method. We can implement a single config for the truncation length (default should be 255 to match the current migration file), but that would not make it possible to have a single column be long while the others keep small.

I suggest solving this bug now with this PR and then we can always create a config or a static property containing individual truncation limits for the different attributes **if** this is actually something that is needed. I would argue that most consumers simply use the `varchar(255)` value specified in the migration file which is also a meaningful length in my opinion.