### PR TITLE
Fix PHP 8.1 deprecation warning when parsing referrer domain name

### DIFF
--- a/src/TrackingFilter.php
+++ b/src/TrackingFilter.php
@@ -68,13 +68,16 @@ class TrackingFilter implements TrackingFilterInterface
             return false;
         }
 
-        $referrer_domain = parse_url($this->request->headers->get('referer'));
-        $referrer_domain = ! isset($referrer_domain['host']) ? null : $referrer_domain['host'];
-        $request_domain = $this->request->server('SERVER_NAME');
+        if ($referrer_domain = $this->request->headers->get('referer')) {
+            $referrer_domain = parse_url($referrer_domain)['host'] ?? null;
+            $request_domain  = $this->request->server('SERVER_NAME');
 
-        if (! empty($referrer_domain) && $referrer_domain == $request_domain) {
-            return true;
+            if ($referrer_domain && ($referrer_domain === $request_domain)) {
+                return true;
+            }
         }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
I've just updated my app to PHP 8.1 and Laravel 9, and noticed log entries building up:

`parse_url(): Passing null to parameter #1 ($url) of type string is deprecated in /my-app/vendor/kyranb/footprints/src/TrackingFilter.php on line 71`

This PR simply tweaks the `disableInternalLinks()` function to avoid calling `parse_url()` when no referrer is available.