### PR TITLE
Add Laravel 11 and PHP 8.2/8.3 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,10 +9,12 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                php: [8.1, 8.0, 7.4]
-                laravel: [7.*, 8.*, 9.*, 10.*]
+                php: [8.3, 8.2, 8.1, 8.0, 7.4]
+                laravel: [7.*, 8.*, 9.*, 10.*, 11.*]
                 dependency-version: [prefer-stable]
                 include:
+                    -   laravel: 11.*
+                        testbench: 9.*
                     -   laravel: 10.*
                         testbench: 8.*
                     -   laravel: 9.*
@@ -30,6 +32,12 @@ jobs:
                         php: 7.4
                     -   laravel: 10.*
                         php: 8.0
+                    -   laravel: 11.*
+                        php: 7.4
+                    -   laravel: 11.*
+                        php: 8.0
+                    -   laravel: 11.*
+                        php: 8.1
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,36 +9,17 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                php: [8.3, 8.2, 8.1, 8.0, 7.4]
-                laravel: [7.*, 8.*, 9.*, 10.*, 11.*]
+                php: [8.3, 8.2, 8.1]
+                laravel: ['10.*', '11.*']
                 dependency-version: [prefer-stable]
                 include:
-                    -   laravel: 11.*
-                        testbench: 9.*
-                    -   laravel: 10.*
-                        testbench: 8.*
-                    -   laravel: 9.*
-                        testbench: 7.*
-                    -   laravel: 8.*
-                        testbench: 6.*
-                    -   laravel: 7.*
-                        testbench: 5.*
+                  - laravel: 10.*
+                    testbench: 8.*
+                  - laravel: 11.*
+                    testbench: 9.*
                 exclude:
-                    -   laravel: 7.*
-                        php: 8.1
-                    -   laravel: 9.*
-                        php: 7.4
-                    -   laravel: 10.*
-                        php: 7.4
-                    -   laravel: 10.*
-                        php: 8.0
-                    -   laravel: 11.*
-                        php: 7.4
-                    -   laravel: 11.*
-                        php: 8.0
-                    -   laravel: 11.*
-                        php: 8.1
-
+                  - laravel: 11.*
+                    php: 8.1
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
         steps:

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0 || ^8.1",
-        "illuminate/support": "^7.0 || ^8.0 || ^9.0 || ^10.0"
+        "php": "^7.4 || ^8.0 || ^8.1 || ^8.2 || ^8.3",
+        "illuminate/support": "^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0"
     },
     "require-dev": {
         "orchestra/testbench": "^6.0",

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0 || ^8.1 || ^8.2 || ^8.3",
-        "illuminate/support": "^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0"
+        "php": "^8.1 || ^8.2 || ^8.3",
+        "illuminate/support": "^10.0 || ^11.0"
     },
     "require-dev": {
         "orchestra/testbench": "^6.0",


### PR DESCRIPTION
This PR adds support for Laravel 11 and PHP 8.2 and 8.3