### PR TITLE
Exclude footprints cookie from encryption

### DIFF
--- a/src/FootprintsServiceProvider.php
+++ b/src/FootprintsServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Kyranb\Footprints;
 
+use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\ServiceProvider;
@@ -16,6 +17,7 @@ class FootprintsServiceProvider extends ServiceProvider
         $this->publishConfig();
         $this->publishMigration();
         $this->bootMacros();
+        $this->disableCookieEncryption();
     }
 
     /**
@@ -46,6 +48,13 @@ class FootprintsServiceProvider extends ServiceProvider
     {
         Request::macro('footprint', function () {
             return App::make(FootprinterInterface::class)->footprint($this);
+        });
+    }
+
+    protected function disableCookieEncryption()
+    {
+        $this->app->resolving(EncryptCookies::class, function (EncryptCookies $middleware) {
+            $middleware->disableFor(config('footprints.cookie_name'));
         });
     }
 

--- a/src/FootprintsServiceProvider.php
+++ b/src/FootprintsServiceProvider.php
@@ -17,9 +17,7 @@ class FootprintsServiceProvider extends ServiceProvider
         $this->publishConfig();
         $this->publishMigration();
         $this->bootMacros();
-        if (config('footprints.cookie_disable_encryption', false)) {
-            $this->disableCookieEncryption();
-        }
+        $this->disableCookieEncryption();
     }
 
     /**

--- a/src/FootprintsServiceProvider.php
+++ b/src/FootprintsServiceProvider.php
@@ -17,7 +17,9 @@ class FootprintsServiceProvider extends ServiceProvider
         $this->publishConfig();
         $this->publishMigration();
         $this->bootMacros();
-        $this->disableCookieEncryption();
+        if (config('footprints.cookie_disable_encryption', false)) {
+            $this->disableCookieEncryption();
+        }
     }
 
     /**

--- a/src/config/footprints.php
+++ b/src/config/footprints.php
@@ -68,19 +68,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Disable Cookie Encryption
-    |--------------------------------------------------------------------------
-    |
-    | When enabled, the footprints cookie will be excluded from Laravel's
-    | EncryptCookies middleware. Enable this if you experience mismatched
-    | footprint values between the first and subsequent requests. The
-    | cookie only contains a non-sensitive SHA1 hash.
-    |
-    */
-    'cookie_disable_encryption' => false,
-
-    /*
-    |--------------------------------------------------------------------------
     | Tracking Filter
     |--------------------------------------------------------------------------
     |

--- a/src/config/footprints.php
+++ b/src/config/footprints.php
@@ -68,6 +68,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Disable Cookie Encryption
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, the footprints cookie will be excluded from Laravel's
+    | EncryptCookies middleware. Enable this if you experience mismatched
+    | footprint values between the first and subsequent requests. The
+    | cookie only contains a non-sensitive SHA1 hash.
+    |
+    */
+    'cookie_disable_encryption' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Tracking Filter
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
## Summary
- Automatically excludes the footprints cookie from Laravel's `EncryptCookies` middleware
- On the first request, the plain fingerprint hash is stored in the database and queued as a cookie. Laravel encrypts it on the response. On the second request, `$request->cookie()` returns the decrypted value, but this can mismatch depending on middleware ordering or if the cookie is read outside the middleware pipeline.
- Fix uses `$middleware->disableFor()` via `resolving()` callback so it works automatically without requiring users to manually edit their `EncryptCookies` middleware

Fixes #72

## Test plan
- [ ] First visit generates a footprint and stores it in the DB
- [ ] Second visit reads the same plain footprint value from the cookie
- [ ] Cookie value matches what's stored in the `visits` table

🤖 Generated with [Claude Code](https://claude.com/claude-code)